### PR TITLE
Correction of an installation error in a future version of zpm

### DIFF
--- a/src/json/Address.cls
+++ b/src/json/Address.cls
@@ -1,6 +1,7 @@
 /// This is a sample embeddable class representing an address. 
 Class json.Address Extends (%SerialObject, %Populate, %JSON.Adaptor)
 {
+
 /// The street address.
 Property Street As %String(MAXLEN = 80, POPSPEC = "Street()");
 
@@ -13,4 +14,26 @@ Property State As %String(MAXLEN = 2, POPSPEC = "USState()");
 /// The 5-digit U.S. Zone Improvement Plan (ZIP) code.
 Property Zip As %String(MAXLEN = 5, POPSPEC = "USZip()");
 
+Storage Default
+{
+<Data name="AddressState">
+<Value name="1">
+<Value>Street</Value>
+</Value>
+<Value name="2">
+<Value>City</Value>
+</Value>
+<Value name="3">
+<Value>State</Value>
+</Value>
+<Value name="4">
+<Value>Zip</Value>
+</Value>
+</Data>
+<State>AddressState</State>
+<StreamLocation>^json.AddressS</StreamLocation>
+<Type>%Storage.Serial</Type>
 }
+
+}
+

--- a/src/json/Person.cls
+++ b/src/json/Person.cls
@@ -24,5 +24,33 @@ Property Home As Address;
 
 /// A collection of strings representing the person's favorite colors.
 Property FavoriteColors As list Of %String(POPSPEC = "ValueList("",Red,Orange,Yellow,Green,Blue,Purple,Black,White""):2");
- 
+
+Storage Default
+{
+<Data name="PersonDefaultData">
+<Value name="1">
+<Value>Name</Value>
+</Value>
+<Value name="2">
+<Value>SSN</Value>
+</Value>
+<Value name="3">
+<Value>DOB</Value>
+</Value>
+<Value name="4">
+<Value>Home</Value>
+</Value>
+<Value name="5">
+<Value>FavoriteColors</Value>
+</Value>
+</Data>
+<DataLocation>^json.PersonD</DataLocation>
+<DefaultData>PersonDefaultData</DefaultData>
+<IdLocation>^json.PersonD</IdLocation>
+<IndexLocation>^json.PersonI</IndexLocation>
+<StreamLocation>^json.PersonS</StreamLocation>
+<Type>%Storage.Persistent</Type>
 }
+
+}
+


### PR DESCRIPTION
This module has a persistent class without any specific storage and this is stated in the error.
The author must define the Storage and publish the new version. The new version of the zpm will have an installation error.

%SYS>ver
%SYS> zpm 0.2.15-dev.228.5

install json-snapshot
 
[json-snapshot] Reload START (D:\InterSystems\IRISPY\mgr\.modules\COLLECTIONINDEXANDQUERY\json-snapshot\1.0.3\)
[json-snapshot] Reload SUCCESS
[json-snapshot] Module object refreshed.
[json-snapshot] Validate START
[json-snapshot] Validate SUCCESS
[json-snapshot] Compile START
[json-snapshot] Compile FAILURE
ERROR! Storage on class json.Address modified by storage compiler, developer should have run ^build to make sure all storage is updated correctly and saved to Perforce          